### PR TITLE
Add git lfs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To play with Open-Vocabulary SAM, you can:
     ```commandline
     git clone https://huggingface.co/spaces/HarborYuan/ovsam ovsam_demo
     cd ovsam_demo
+    git lfs pull
     conda create -n ovsam_demo python=3.10  && conda activate ovsam_demo
     python -m pip install gradio==4.7.1
     python -m pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To play with Open-Vocabulary SAM, you can:
     ```commandline
     git clone https://huggingface.co/spaces/HarborYuan/ovsam ovsam_demo
     cd ovsam_demo
-    git lfs pull
+    git lfs install
     conda create -n ovsam_demo python=3.10  && conda activate ovsam_demo
     python -m pip install gradio==4.7.1
     python -m pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ To play with Open-Vocabulary SAM, you can:
 1. Try the online demo on the [🤗Hugging Face Space](https://huggingface.co/spaces/HarborYuan/ovsam). Thanks for the generous support of the Hugging Face team.
 2. Run the gradio demo locally by cloning and running the [repo](https://huggingface.co/spaces/HarborYuan/ovsam/tree/main) on 🤗Hugging Face:
     ```commandline
+    git lfs install
     git clone https://huggingface.co/spaces/HarborYuan/ovsam ovsam_demo
     cd ovsam_demo
-    git lfs install
     conda create -n ovsam_demo python=3.10  && conda activate ovsam_demo
     python -m pip install gradio==4.7.1
     python -m pip install -r requirements.txt


### PR DESCRIPTION
When I tried following the readme to start the gradio demo, I got an error due to missing the weights, since they are not downloaded in the initial git checkout. Running `git lfs pull` fixed my issue. This change adds the `git lfs pull` step to the readme.